### PR TITLE
builtin_pwd.c 에러 처리 부분 추가

### DIFF
--- a/includes/minishell.h
+++ b/includes/minishell.h
@@ -7,6 +7,9 @@
 # include <errno.h>
 # include <fcntl.h>
 # include <signal.h>
+# include <sys/param.h>
 # include "../libft/libft.h"
+
+void	builtin_pwd(void);
 
 #endif

--- a/src/builtin_pwd.c
+++ b/src/builtin_pwd.c
@@ -1,11 +1,20 @@
 #include "../includes/minishell.h"
 
+/*
+** builtin_pwd: get current working directory path using getcwd().
+** if getcwd() fails, it returns -1 and pwd prints error msg.
+** if success, pwd prints the path of current working directory.
+*/
 void	builtin_pwd(void)
 {
 	char	buf[MAXPATHLEN];
 	char	*ptr;
 
-	ptr = getcwd(buf, MAXPATHLEN);
+	if (!(ptr = getcwd(buf, MAXPATHLEN)))
+	{
+		write(2, "pwd: Failed to get path. Check the buffer size.\n", 48);
+		return ;
+	}
 	write(1, ptr, ft_strlen(ptr));
 	write(1, "\n", 1);
 }

--- a/src/builtin_pwd.c
+++ b/src/builtin_pwd.c
@@ -1,0 +1,11 @@
+#include "../includes/minishell.h"
+
+void	builtin_pwd(void)
+{
+	char	buf[MAXPATHLEN];
+	char	*ptr;
+
+	ptr = getcwd(buf, MAXPATHLEN);
+	write(1, ptr, ft_strlen(ptr));
+	write(1, "\n", 1);
+}


### PR DESCRIPTION
builtin_pwd 에서 getcwd() 함수가 NULL 포인터를 반환할 때 에러 메시지를 출력하도록 수정.