### PR TITLE
Feature/builtin exit

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,7 @@ SRCS =	./src/main.c \
 		./src/builtin_export.c \
 		./src/builtin_export2.c \
 		./src/builtin_unset.c \
+		./src/builtin_exit.c \
 		./src/utils.c \
 		./src/utils_env.c
 

--- a/includes/minishell.h
+++ b/includes/minishell.h
@@ -52,19 +52,20 @@ void			set_exit_status(int status);
 **	utils_env.c
 */
 char			*find_value(char *key);
+int				get_number_envs(void);
 /*
 **  builtin_export.c
 */
-int		does_exist_env_oldpwd(void);
-void	print_env_list(void);
-int		get_parsing_idx(char *arg);
-void	convert_empty_string_to_null(char **value);
-int		get_number_envs(void);
+int				does_exist_env_oldpwd(void);
+void			print_env_list(void);
+int				get_parsing_idx(char *arg);
+void			convert_empty_string_to_null(char **value);
 /*
 **  builtin_export2.c
 */
-int		does_exist_same_env(char **key, char **value, int num_envs);
-void	make_new_env_list(char **key, char **value, int num_envs);
-void	set_env(char *arg);
-void	builtin_export(char *line);
+int				does_exist_same_env(char **key, char **value, int num_envs);
+void			set_env_list_last_data(char *key, char *value, int idx);
+void			make_new_env_list(char **key, char **value, int num_envs);
+void			set_env(char *arg);
+void			builtin_export(char *line);
 #endif

--- a/includes/minishell.h
+++ b/includes/minishell.h
@@ -19,6 +19,7 @@ typedef	struct	s_env
 }				t_env;
 
 t_env			*g_env_list;
+int				g_exit_status;
 
 void			builtin_pwd(void);
 void			builtin_cd(char *line);
@@ -46,6 +47,7 @@ int				exec_buitlin(char *line);
 */
 void			free_double_pointer(char **args);
 int				two_ptr_size(char **ptr);
+void			set_exit_status(int status);
 /*
 **	utils_env.c
 */

--- a/includes/minishell.h
+++ b/includes/minishell.h
@@ -26,6 +26,7 @@ void			builtin_echo(char *arg);
 void			builtin_env();
 void			builtin_export(char *line);
 void			builtin_unset(char *line);
+void			builtin_exit(char *line);
 
 /*
 **	parse_line.c

--- a/src/builtin_echo.c
+++ b/src/builtin_echo.c
@@ -13,9 +13,11 @@ void	builtin_echo(char *line)
 	int		idx;
 	int		n_option;
 
+	set_exit_status(0);
 	if (!(arg_list = ft_split(line, ' ')))
 	{
 		ft_putstr_fd("error: can't allocate memory.\n", 2);
+		set_exit_status(1);
 		return ;
 	}
 	if (arg_list[1] == NULL)

--- a/src/builtin_echo.c
+++ b/src/builtin_echo.c
@@ -1,10 +1,31 @@
 #include "../includes/minishell.h"
 
 /*
+** print_args_echo: print args.
+** if -n option exist(n_option = 1), line ends without newline.
+** otherwise(n_option = 0), line ends with newline.
+*/
+
+void	print_args_echo(int n_option, char **arg_list)
+{
+	int		idx;
+
+	idx = 1;
+	if (n_option != 0)
+		idx = 0;
+	while (arg_list[++idx])
+	{
+		ft_putstr_fd(arg_list[idx], 1);
+		if (arg_list[idx + 1])
+			ft_putstr_fd(" ", 1);
+	}
+	if (n_option != 0)
+		ft_putstr_fd("\n", 1);
+}
+
+/*
 ** builtin_echo: print line. for example, line is "echo hello world".
 ** so, arg_list[0] must be "echo".
-** if -n option exist, line ends without newline.
-** otherwise, line ends with newline.
 */
 
 void	builtin_echo(char *line)
@@ -28,15 +49,6 @@ void	builtin_echo(char *line)
 	}
 	idx = 1;
 	n_option = ft_strncmp(arg_list[1], "-n", ft_strlen(arg_list[1]));
-	if (n_option != 0)
-		idx = 0;
-	while (arg_list[++idx])
-	{
-		ft_putstr_fd(arg_list[idx], 1);
-		if (arg_list[idx + 1])
-			ft_putstr_fd(" ", 1);
-	}
-	if (n_option != 0)
-		ft_putstr_fd("\n", 1);
+	print_args_echo(n_option, arg_list);
 	free_double_pointer(arg_list);
 }

--- a/src/builtin_env.c
+++ b/src/builtin_env.c
@@ -11,6 +11,7 @@ void	builtin_env(void)
 {
 	int	idx;
 
+	set_exit_status(0);
 	idx = -1;
 	while (g_env_list[++idx].key)
 	{

--- a/src/builtin_exit.c
+++ b/src/builtin_exit.c
@@ -1,0 +1,35 @@
+#include "../includes/minishell.h"
+
+void	builtin_exit(char *line)
+{
+	char	**arg_list;
+	int		idx;
+
+	if (!(arg_list = ft_split(line, ' ')))
+	{
+		ft_putstr_fd("error: can't allocate memory.\n", 2);
+		return ;
+	}
+	if (two_ptr_size(arg_list) > 2)
+	{
+		ft_putstr_fd("error: exit: too many arguments.\n", 2);
+		return ;
+	}
+	ft_putstr("exit\n");
+	if (arg_list[1] == NULL)
+		exit(0);
+	idx = -1;
+	if (arg_list[1][0] == '-' || arg_list[1][0] == '+')
+		idx++;
+	while (arg_list[1][++idx])
+	{
+		if (!(arg_list[1][idx] >= '0' && arg_list[1][idx] <= '9'))
+		{
+			ft_putstr_fd("error: exit: ", 2);
+			ft_putstr_fd(arg_list[1], 2);
+			ft_putstr_fd(": numeric argument required.\n", 2);
+			exit(255);
+		}
+	}
+	exit(ft_atoi(arg_list[1]) % 256);
+}

--- a/src/builtin_exit.c
+++ b/src/builtin_exit.c
@@ -1,9 +1,41 @@
 #include "../includes/minishell.h"
 
+/*
+** check_if_arg_is_num: check whether exit's arg is number.
+** if it is number, it works.
+** if it is not number, programs occurs error and return 255.
+*/
+
+void	check_if_arg_is_num(char *str)
+{
+	int		idx;
+
+	idx = -1;
+	if (str[0] == '-' || str[0] == '+')
+		idx++;
+	while (str[++idx])
+	{
+		if (!(str[idx] >= '0' && str[idx] <= '9'))
+		{
+			ft_putstr_fd("error: exit: ", 2);
+			ft_putstr_fd(str, 2);
+			ft_putstr_fd(": numeric argument required.\n", 2);
+			exit(255);
+		}
+	}
+}
+
+/*
+** builtin_exit: when the command is 'exit', the shell will be exited.
+** and it will return 0 if it works normally.
+** but, if there is an error, the shell will return 1.
+** if 'exit' command has argument, the shell will return the argument.
+** for example, if the command is 'exit 128', the shell will return 128.
+*/
+
 void	builtin_exit(char *line)
 {
 	char	**arg_list;
-	int		idx;
 
 	if (!(arg_list = ft_split(line, ' ')))
 	{
@@ -20,18 +52,6 @@ void	builtin_exit(char *line)
 	ft_putstr("exit\n");
 	if (arg_list[1] == NULL)
 		exit(0);
-	idx = -1;
-	if (arg_list[1][0] == '-' || arg_list[1][0] == '+')
-		idx++;
-	while (arg_list[1][++idx])
-	{
-		if (!(arg_list[1][idx] >= '0' && arg_list[1][idx] <= '9'))
-		{
-			ft_putstr_fd("error: exit: ", 2);
-			ft_putstr_fd(arg_list[1], 2);
-			ft_putstr_fd(": numeric argument required.\n", 2);
-			exit(255);
-		}
-	}
+	check_if_arg_is_num(arg_list[1]);
 	exit(ft_atoi(arg_list[1]) % 256);
 }

--- a/src/builtin_exit.c
+++ b/src/builtin_exit.c
@@ -8,11 +8,13 @@ void	builtin_exit(char *line)
 	if (!(arg_list = ft_split(line, ' ')))
 	{
 		ft_putstr_fd("error: can't allocate memory.\n", 2);
+		set_exit_status(1);
 		return ;
 	}
 	if (two_ptr_size(arg_list) > 2)
 	{
 		ft_putstr_fd("error: exit: too many arguments.\n", 2);
+		set_exit_status(1);
 		return ;
 	}
 	ft_putstr("exit\n");

--- a/src/builtin_export.c
+++ b/src/builtin_export.c
@@ -85,17 +85,3 @@ void	convert_empty_string_to_null(char **value)
 		free(tmp);
 	}
 }
-
-/*
-** get_number_envs: return the number of environments.
-*/
-
-int		get_number_envs(void)
-{
-	int		idx;
-
-	idx = -1;
-	while (g_env_list[++idx].key)
-		;
-	return (idx);
-}

--- a/src/builtin_export2.c
+++ b/src/builtin_export2.c
@@ -29,6 +29,18 @@ int		does_exist_same_env(char **key, char **value, int num_envs)
 }
 
 /*
+** set_env_list_last_data: this function sets the last data of g_env_list.
+*/
+
+void	set_env_list_last_data(char *key, char *value, int idx)
+{
+	g_env_list[idx].key = ft_strdup(key);
+	g_env_list[idx].value = value == NULL ? NULL : ft_strdup(value);
+	g_env_list[idx + 1].key = NULL;
+	g_env_list[idx + 1].value = NULL;
+}
+
+/*
 ** make_new_env_list: expand g_env_list.
 */
 
@@ -56,10 +68,7 @@ void	make_new_env_list(char **key, char **value, int num_envs)
 		free(orig_env_list[idx].value);
 	}
 	free(orig_env_list);
-	g_env_list[idx].key = ft_strdup(*key);
-	g_env_list[idx].value = *value == NULL ? NULL : ft_strdup(*value);
-	g_env_list[idx + 1].key = NULL;
-	g_env_list[idx + 1].value = NULL;
+	set_env_list_last_data(*key, *value, idx);
 	free(*key);
 	free(*value);
 }

--- a/src/builtin_export2.c
+++ b/src/builtin_export2.c
@@ -43,6 +43,7 @@ void	make_new_env_list(char **key, char **value, int num_envs)
 		ft_putstr_fd("error: can't allocate memory.\n", 2);
 		free(*key);
 		free(*value);
+		set_exit_status(1);
 		return ;
 	}
 	idx = -1;
@@ -76,7 +77,10 @@ void	set_env(char *arg)
 
 	parsing_idx = get_parsing_idx(arg);
 	if (parsing_idx == -1)
+	{
+		set_exit_status(1);
 		return ;
+	}
 	key = ft_substr(arg, 0, parsing_idx);
 	value = ft_substr(arg, parsing_idx + 1, ft_strlen(arg));
 	convert_empty_string_to_null(&value);
@@ -98,9 +102,11 @@ void	builtin_export(char *line)
 	int		idx;
 	char	**arg_list;
 
+	set_exit_status(0);
 	if (!(arg_list = ft_split(line, ' ')))
 	{
 		ft_putstr_fd("error: can't allocate memory.\n", 2);
+		set_exit_status(1);
 		return ;
 	}
 	if (arg_list[1] == NULL)

--- a/src/builtin_pwd.c
+++ b/src/builtin_pwd.c
@@ -5,6 +5,7 @@
 ** if getcwd() fails, it returns -1 and pwd prints error msg.
 ** if success, pwd prints the path of current working directory.
 */
+
 void	builtin_pwd(void)
 {
 	char	buf[MAXPATHLEN];

--- a/src/builtin_pwd.c
+++ b/src/builtin_pwd.c
@@ -12,9 +12,11 @@ void	builtin_pwd(void)
 
 	if (!(ptr = getcwd(buf, MAXPATHLEN)))
 	{
-		write(2, "pwd: Failed to get path. Check the buffer size.\n", 48);
+		ft_putstr_fd("pwd: Failed to get path. Check the buffer size.\n", 2);
+		set_exit_status(1);
 		return ;
 	}
-	write(1, ptr, ft_strlen(ptr));
-	write(1, "\n", 1);
+	ft_putstr_fd(ptr, 1);
+	ft_putstr("\n");
+	set_exit_status(0);
 }

--- a/src/builtin_unset.c
+++ b/src/builtin_unset.c
@@ -1,16 +1,69 @@
 #include "../includes/minishell.h"
 
-void	make_new_env_list_unset(char *key, int num_envs)
+/*
+** move_data_to_g_env_list: move data from original array
+** to g_env_list(reduced array size).
+*/
+
+void	move_data_to_g_env_list(char *key, int num_envs, t_env **orig_env_list)
 {
 	int		idx;
 	int		idx2;
-	t_env	*orig_env_list;
+
+	idx = -1;
+	idx2 = 0;
+	while (++idx < num_envs)
+	{
+		if (ft_strncmp(key, (*orig_env_list)[idx].key, ft_strlen(key)) == 0
+				&& key[ft_strlen(key)] == '\0')
+		{
+			free((*orig_env_list)[idx].key);
+			free((*orig_env_list)[idx].value);
+			continue ;
+		}
+		g_env_list[idx2].key = ft_strdup((*orig_env_list)[idx].key);
+		g_env_list[idx2].value = (*orig_env_list)[idx].value == NULL ?
+			NULL : ft_strdup((*orig_env_list)[idx].value);
+		free((*orig_env_list)[idx].key);
+		free((*orig_env_list)[idx].value);
+		idx2++;
+	}
+	g_env_list[idx2].key = NULL;
+	g_env_list[idx2].value = NULL;
+	free((*orig_env_list));
+}
+
+/*
+** is_arg_in_env_list: find the key in g_env_list.
+** if it is, return 1. otherwise, return 0.
+*/
+
+int		is_arg_in_env_list(char *key, int num_envs)
+{
+	int		idx;
 
 	idx = -1;
 	while (g_env_list[++idx].key)
-		if (ft_strncmp(g_env_list[idx].key, key, ft_strlen(key)) == 0 && key[ft_strlen(key)] == '\0')
+		if (ft_strncmp(g_env_list[idx].key, key, ft_strlen(key)) == 0
+				&& key[ft_strlen(key)] == '\0')
 			break ;
 	if (idx == num_envs)
+		return (1);
+	return (0);
+}
+
+/*
+** make_new_env_list_unset: make new array for env_list to run unset command.
+** first, find the key that is same as 'unset' arg.
+** if so, the function will return. otherwise, make new env list reduced size
+** and move datas to new env list.
+*/
+
+void	make_new_env_list_unset(char *key, int num_envs)
+{
+	t_env	*orig_env_list;
+
+	if (is_arg_in_env_list(key, num_envs) == 1)
 		return ;
 	orig_env_list = g_env_list;
 	if (!(g_env_list = (t_env*)malloc(sizeof(t_env) * (num_envs))))
@@ -20,28 +73,14 @@ void	make_new_env_list_unset(char *key, int num_envs)
 		set_exit_status(1);
 		return ;
 	}
-	idx = -1;
-	idx2 = 0;
-	while (++idx < num_envs)
-	{
-		if (ft_strncmp(key, orig_env_list[idx].key, ft_strlen(key)) == 0
-				&& key[ft_strlen(key)] == '\0')
-		{
-			free(orig_env_list[idx].key);
-			free(orig_env_list[idx].value);
-			continue ;
-		}
-		g_env_list[idx2].key = ft_strdup(orig_env_list[idx].key);
-		g_env_list[idx2].value = orig_env_list[idx].value == NULL ?
-			NULL : ft_strdup(orig_env_list[idx].value);
-		free(orig_env_list[idx].key);
-		free(orig_env_list[idx].value);
-		idx2++;
-	}
-	g_env_list[idx2].key = NULL;
-	g_env_list[idx2].value = NULL;
-	free(orig_env_list);
+	move_data_to_g_env_list(key, num_envs, &orig_env_list);
 }
+
+/*
+** builtin_unset: when the command is 'unset', this function is started.
+** this function find arg as environmenet and unset the environment.
+** if there is no environment same as arg, nothing will be happened.
+*/
 
 void	builtin_unset(char *line)
 {

--- a/src/builtin_unset.c
+++ b/src/builtin_unset.c
@@ -1,6 +1,6 @@
 #include "../includes/minishell.h"
 
-void	make_new_env_list2(char *key, int num_envs)
+void	make_new_env_list_unset(char *key, int num_envs)
 {
 	int		idx;
 	int		idx2;
@@ -17,6 +17,7 @@ void	make_new_env_list2(char *key, int num_envs)
 	{
 		ft_putstr_fd("error: can't allocate memory.\n", 2);
 		orig_env_list = NULL;
+		set_exit_status(1);
 		return ;
 	}
 	idx = -1;
@@ -47,9 +48,11 @@ void	builtin_unset(char *line)
 	int		idx;
 	char	**arg_list;
 
+	set_exit_status(0);
 	if (!(arg_list = ft_split(line, ' ')))
 	{
 		ft_putstr_fd("error: can't allocate memory.\n", 2);
+		set_exit_status(1);
 		return ;
 	}
 	if (arg_list[1] == NULL)
@@ -59,6 +62,6 @@ void	builtin_unset(char *line)
 	}
 	idx = 0;
 	while (arg_list[++idx])
-		make_new_env_list2(arg_list[idx], get_number_envs());
+		make_new_env_list_unset(arg_list[idx], get_number_envs());
 	free_double_pointer(arg_list);
 }

--- a/src/exec_cmds.c
+++ b/src/exec_cmds.c
@@ -21,6 +21,8 @@ int		exec_buitlin(char *line)
 		builtin_export(line);
 	else if (ft_strncmp(line, "unset", 5) == 0 && (line[5] == 0 || line[5] == ' '))
 		builtin_unset(line);
+	else if (ft_strncmp(line, "exit", 4) == 0 && (line[4] == 0 || line[4] == ' '))
+		builtin_exit(line);
 	else
 	{
 		ft_putstr_fd("exec_builtin error\n", 1);

--- a/src/main.c
+++ b/src/main.c
@@ -91,8 +91,9 @@ int			main(int argc, char *argv[], char *envp[])
 	if (argc != 1)
 		argv[0] = NULL;
 
+	g_exit_status = 0;
 	parse_env(envp);
 	print_prompt();
 
-	return (0);
+	return (g_exit_status);
 }

--- a/src/utils.c
+++ b/src/utils.c
@@ -23,3 +23,12 @@ void	free_double_pointer(char **args)
 		free(args[idx]);
 	free(args);
 }
+
+/*
+** set_exit_status
+*/
+
+void	set_exit_status(int status)
+{
+	g_exit_status = status;
+}

--- a/src/utils_env.c
+++ b/src/utils_env.c
@@ -15,3 +15,17 @@ char	*find_value(char *key)
 	}
 	return (NULL);
 }
+
+/*
+** get_number_envs: return the number of environments.
+*/
+
+int		get_number_envs(void)
+{
+	int		idx;
+
+	idx = -1;
+	while (g_env_list[++idx].key)
+		;
+	return (idx);
+}


### PR DESCRIPTION
1. exit 기능을 추가하였습니다.
2. 내장함수나 프로그램 종료시 종료 상태를 설정하기 위해 g_exit_status 변수를 정의하였으며,
이를 설정하는 함수인 set_exit_status를 정의하였습니다.
3. 내장함수에서 exit status를 설정하도록 코드를 수정하였습니다.
4. get_number_envs 함수를 src/builtin_export.c에서 src/utils.c 파일로 이동하였습니다.
5. norminette을 통과하기 위해 builtin 함수의 코드를 수정하였습니다. 단, src/builtin_cd.c 파일은 아직 수정하지 않았습니다.
또한 주석이 한글로 쓰여진 경우 과카몰리(https://guacamole.42seoul.kr/)의 ssh에서 norminette을 돌렸을 때 에러가 발생합니다.
실제 클러스터에서도 에러가 발생하는지 여부는 확인하지 못하였으며, 주석에 대한 처리를 추후 논의해야 할 것으로 보입니다.