### PR TITLE
fix execve parse_path_list

### DIFF
--- a/src/execve.c
+++ b/src/execve.c
@@ -15,8 +15,11 @@ char		**parse_path_list(void)
 	temp_value = find_value(g_env_list[idx].key);
 	*/
 	temp_value = find_value("PATH");
+	/*
 	if (!(result = ft_split(temp_value, ':')))
 		return (NULL);
+		*/
+	result = ft_split(temp_value, ':');
 	return (result);
 }
 
@@ -144,8 +147,7 @@ void		cmd_execve(t_command *cmd)
 
 	if (!(path_list = parse_path_list()))
 	{
-		ft_putstr_fd("error: can't allocate memory.\n", 2);
-		set_res(1);
+		print_error_msg(cmd->cmd, "command not found", 127, NULL);
 		return ;
 	}
 	full_cmd = NULL;


### PR DESCRIPTION
1. execve.c 의 parse_path_list함수에서 split 부분을 수정하였습니다.
#64 와 관련 있는 부분이며, `unset PATH`를 통해 $PATH의 value가 없는 경우 `command not found.` 에러 메시지를 출력합니다.